### PR TITLE
Add user panel to header

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cssVariables.lookupFiles": [
+    "client/src/index.css"
+  ]
+}

--- a/client/src/components/App/App.css
+++ b/client/src/components/App/App.css
@@ -1,3 +1,8 @@
+body {
+  width: 100vw;
+  overflow: hidden;
+}
+
 .dashboard {
   background-color: var(--background);
   display: flex;

--- a/client/src/components/App/App.jsx
+++ b/client/src/components/App/App.jsx
@@ -4,6 +4,7 @@ import { StockCounterContext, stockCounterSettings } from '../../contexts/stock-
 import './App.css';
 import Header from '../BaseComponents/Header/Header';
 import Menu from '../BaseComponents/Menu/Menu';
+import UserPanel from '../Panels/UserPanel/UserPanel';
 import Home from '../Pages/Home/Home';
 
 class App extends React.Component {
@@ -14,6 +15,7 @@ class App extends React.Component {
         settings: stockCounterSettings,
       },
       navOpen: true,
+      panelOpen: false,
     };
 
     this.setNavOpen = this.setNavOpen.bind(this);
@@ -43,19 +45,26 @@ class App extends React.Component {
 
   setNavOpen() {
     this.setState((prevState) => ({
-      navOpen: !prevState.mavOpen,
+      navOpen: !prevState.navOpen,
+    }));
+  }
+
+  setPanelOpen() {
+    this.setState((prevState) => ({
+      panelOpen: !prevState.panelOpen,
     }));
   }
 
   render() {
-    const { navOpen, value } = this.state;
+    const { navOpen, value, panelOpen } = this.state;
 
     return (
       <Router>
         <div className="App">
-          <Header openNav={() => this.setNavOpen} />
+          <Header openNav={() => this.setNavOpen()} openPanel={() => this.setPanelOpen()} />
           <div className="dashboard">
             <Menu navOpen={navOpen} />
+            <UserPanel panelOpen={panelOpen} closePanel={() => this.setPanelOpen()} />
             <main>
               <StockCounterContext.Provider value={value}>
                 <Switch>

--- a/client/src/components/BaseComponents/Header/Header.jsx
+++ b/client/src/components/BaseComponents/Header/Header.jsx
@@ -1,16 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Menu } from 'react-feather';
+import { Menu, User } from 'react-feather';
 import './header.css';
 
-const Header = ({ openNav }) => (
+const Header = ({ openNav, openPanel }) => (
   <div className="header">
     <Menu
       size={28}
-      strokeWidth={2}
+      strokeWidth={1.5}
       role="button"
       onClick={openNav}
       onKeyPress={openNav}
+      tabIndex={-1}
+    />
+
+    <User
+      size={28}
+      strokeWidth={1.5}
+      role="button"
+      onClick={openPanel}
+      onKeyPress={openPanel}
       tabIndex={0}
     />
   </div>
@@ -18,6 +27,7 @@ const Header = ({ openNav }) => (
 
 Header.propTypes = {
   openNav: PropTypes.func.isRequired,
+  openPanel: PropTypes.func.isRequired,
 };
 
 export default Header;

--- a/client/src/components/BaseComponents/Header/header.css
+++ b/client/src/components/BaseComponents/Header/header.css
@@ -1,10 +1,11 @@
 .header {
-  width: calc(100vw - var(--space-m));
+  width: calc(100vw - var(--space-m) - var(--space-m));
   height: var(--space-xxl);
   background: var(--primary-variant);
   color: var(--on-primary);
-  padding-left: var(--space-m);
+  padding: 0 var(--space-m);
   display: flex;
-  flex-direction: column;
-  justify-content: center;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
 }

--- a/client/src/components/BaseComponents/Input/Input.css
+++ b/client/src/components/BaseComponents/Input/Input.css
@@ -20,3 +20,7 @@ input:focus {
   outline: none;
   border-bottom: 2px solid var(--secondary);
 }
+
+.secondary:focus {
+  border-bottom: 2px solid var(--secondary-variant);
+}

--- a/client/src/components/BaseComponents/Input/NumberInput.jsx
+++ b/client/src/components/BaseComponents/Input/NumberInput.jsx
@@ -2,10 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import './Input.css';
 
-const NumberInput = ({ identifier, label, value, handleChange, step, min, max, readOnly }) => (
+const NumberInput = ({
+  identifier,
+  label,
+  value,
+  handleChange,
+  step,
+  min,
+  max,
+  readOnly,
+  secondary,
+}) => (
   <label htmlFor={identifier}>
     {label}
     <input
+      className={`${secondary ? 'secondary' : ''}`}
       type="number"
       value={value}
       id={identifier}
@@ -26,6 +37,7 @@ NumberInput.propTypes = {
   step: PropTypes.string,
   min: PropTypes.string,
   max: PropTypes.string,
+  secondary: PropTypes.bool,
   readOnly: PropTypes.bool,
 };
 
@@ -34,6 +46,7 @@ NumberInput.defaultProps = {
   min: 'any',
   max: 'any',
   readOnly: false,
+  secondary: false,
   handleChange: () => {},
 };
 

--- a/client/src/components/BaseComponents/Input/TextInput.jsx
+++ b/client/src/components/BaseComponents/Input/TextInput.jsx
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import './Input.css';
 
-const TextInput = ({ identifier, label, value, handleChange }) => (
+const TextInput = ({ identifier, label, value, handleChange, secondary }) => (
   <label htmlFor={identifier}>
     {label}
     <input
+      className={`${secondary ? 'secondary' : ''}`}
       type="text"
       value={value}
       id={identifier}
@@ -19,6 +20,11 @@ TextInput.propTypes = {
   value: PropTypes.string.isRequired,
   handleChange: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
+  secondary: PropTypes.bool,
+};
+
+TextInput.defaultProps = {
+  secondary: false,
 };
 
 export default TextInput;

--- a/client/src/components/Panels/UserPanel/UserPanel.js
+++ b/client/src/components/Panels/UserPanel/UserPanel.js
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { X } from 'react-feather';
+import NumberInput from '../../BaseComponents/Input/NumberInput';
+import TextInput from '../../BaseComponents/Input/TextInput';
+import './userPanel.css';
+import {
+  getNumberStoredItem,
+  getStringStoredItem,
+  setLocalStorageItem,
+} from '../../../lib/localStorage';
+
+const UserPanel = ({ panelOpen, closePanel }) => {
+  const [minCourtage, setMinCourtage] = useState(getNumberStoredItem('minCourtage'));
+  const [percentageCourtage, setPercentageCourtage] = useState(
+    getNumberStoredItem('percentageCourtage')
+  );
+  const [currencyCourtage, setCurrencyCourtage] = useState(getNumberStoredItem('currencyCourtage'));
+  const [baseCurrency, setBaseCurrency] = useState(getStringStoredItem('baseCurrency'));
+  const [currencyExchange, setCurrencyExchange] = useState(getNumberStoredItem('currencyExchange'));
+
+  return (
+    <div className={`panel ${panelOpen ? '' : 'hidden'}`}>
+      <div className="panel-heading">
+        Heading
+        <X size={24} strokeWidth={1.5} role="button" onClick={closePanel} />
+      </div>
+      <div className="panel-body">
+        <NumberInput
+          identifier="min-courtage"
+          label="Min. courtage"
+          value={minCourtage}
+          handleChange={(value) => {
+            setMinCourtage(value);
+            setLocalStorageItem('minCourtage', value);
+          }}
+          secondary
+        />
+        <NumberInput
+          identifier="percentage-courtage"
+          label="Percentage courtage"
+          value={percentageCourtage}
+          handleChange={(value) => {
+            setPercentageCourtage(value);
+            setLocalStorageItem('percentageCourtage', value);
+          }}
+          secondary
+        />
+        <NumberInput
+          identifier="currency-courtage"
+          label="Currency courtage"
+          value={currencyCourtage}
+          handleChange={(value) => {
+            setCurrencyCourtage(value);
+            setLocalStorageItem('currencyCourtage', value);
+          }}
+          secondary
+        />
+        <NumberInput
+          identifier="currency-exchange"
+          label="Currency exchange"
+          value={currencyExchange}
+          handleChange={(value) => {
+            setCurrencyExchange(value);
+            setLocalStorageItem('currencyExchange', value);
+          }}
+          secondary
+        />
+        <TextInput
+          identifier="base-currency"
+          label="Base currency"
+          value={baseCurrency}
+          handleChange={(value) => {
+            setBaseCurrency(value);
+            setLocalStorageItem('baseCurrency', value);
+          }}
+          secondary
+        />
+      </div>
+    </div>
+  );
+};
+
+UserPanel.propTypes = {
+  panelOpen: PropTypes.bool.isRequired,
+  closePanel: PropTypes.func.isRequired,
+};
+
+export default UserPanel;

--- a/client/src/components/Panels/UserPanel/userPanel.css
+++ b/client/src/components/Panels/UserPanel/userPanel.css
@@ -1,0 +1,34 @@
+.panel {
+  width: 300px;
+  position: absolute;
+  height: calc(100vh - var(--space-xxl));
+  display: flex;
+  flex-direction: column;
+  background: var(--primary-variant);
+  color: var(--on-primary);
+  overflow: hidden;
+  transition: all 1s;
+  right: 0;
+}
+
+.panel.hidden {
+  transform: translateX(300px);
+}
+
+.panel-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-m);
+  font-size: var(--font-h4);
+}
+
+.panel-body {
+  padding: var(--space-m);
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-body > * {
+  margin-bottom: var(--space-l);
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,6 +5,7 @@
   --primary-variant: hsl(0, 0%, 9%);
   --secondary: hsl(185, 100%, 28%);
   --on-primary: hsl(0, 0%, 100%);
+  --secondary-variant: hsl(0, 0%, 91%);
   --hover-on-primary: hsl(0, 0%, 24%);
   --color-lines: hsl(0, 0%, 62%);
 


### PR DESCRIPTION
Inside the user panel settings for courtage and currency has been
added and updates those values in localStorage. However when updating
localStorage the home-component doesn't rerender on updates in
localStorage (as it should), so to create a better flow redux will
be added in a separate commit to complete the functionality.